### PR TITLE
added support for Awesomplete's label/value array

### DIFF
--- a/src/VueTagger.vue
+++ b/src/VueTagger.vue
@@ -97,7 +97,7 @@ export default {
       }
     },
     getTagIndexByName (name) {
-      return this.tagList.findIndex(tag => tag.name.trim().toLowerCase() === name.trim().toLowerCase())
+      return this.tagList.findIndex(tag => Array.isArray(tag.name) ? tag.name[1].trim().toLowerCase() : tag.name.trim().toLowerCase() === name.trim().toLowerCase())
     },
     addTag (name) {
       const tagIndex = this.getTagIndexByName(name)


### PR DESCRIPTION
Support an array in names, so we can get more descriptive autocomplete prompt, but still use short tag as a value.
tags: [
        { name: 'JavaScript', selected: true },
        { name: ['Ruby','Ruby awesome'], selected: false }
]